### PR TITLE
Fix SlashCommandLine parsing for empty names

### DIFF
--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -321,7 +321,22 @@ impl SlashCommandLine {
             }
             ix = next_ix;
         }
-        call
+        if let Some(mut call) = call {
+            // ensure the command name is not empty
+            if call.name.is_empty() {
+                return None;
+            }
+
+            // trim trailing empty argument if the user ended the line with
+            // whitespace
+            if matches!(call.arguments.last(), Some(arg) if arg.is_empty()) {
+                call.arguments.pop();
+            }
+
+            Some(call)
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- fix `SlashCommandLine::parse` when line only contains `/`
- drop trailing empty argument when line ends with whitespace

## Testing
- `cargo check -p assistant_slash_command` *(fails: failed to load source for dependency `cpal`)*